### PR TITLE
Add talkSPORT app, Times Radio app and Virgin Radio app from v1

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3790,6 +3790,32 @@
       "examples": [
         "Mozilla/5.0 (Mobile; LYF/F271i/LYF_F271i-000-01-20-101019; Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5"
       ]
+    },
+    {
+      "name": "talkSPORT app",
+      "pattern": "(^talkSPORT.+Android|^talkSPORT.+Darwin)",
+      "examples": [
+        "talkSPORT/x.x.x.xxx.xxx (Linux; Android x) ExoPlayerLib/x.xx.x",
+        "talkSPORT/xxxxxxxxxxx CFNetwork/1126 Darwin/19.5.0"
+      ]
+    },
+    {
+      "name": "Times Radio app",
+      "pattern": "(^Times%20Radio.+Android|^Times\\sRadio.+Android|^Times%20Radio.+Darwin|^Times\\sRadio.+Darwin)",
+      "examples": [
+        "Times%20Radio/x.x.x.xxx.xxx (Linux; Android x) ExoPlayerLib/x.xx.x",
+        "Times%20Radio/xxxxxxxxxxx CFNetwork/1126 Darwin/19.5.0",
+        "Times%20Radio/45.2.0.22025 / (Linux; Android 13) ExoPlayerLib/2.17.1 / samsung (SM-A145R)"
+      ]
+    },
+    {
+      "name": "Virgin Radio app",
+      "pattern": "(^Virgin%20Radio.+Android|^Virgin\\sRadio.+Android|^Virgin%20Radio.+Darwin|^Virgin\\sRadio.+Darwin)",
+      "examples": [
+        "Virgin%20Radio/x.x.x.xxx.xxx (Linux; Android x) ExoPlayerLib/x.xx.x",
+        "Virgin%20Radio/xxxxxxxxxxx CFNetwork/1126 Darwin/19.5.0",
+        "Virgin%20Radio/45.2.0.22026 / (Linux; Android 14) ExoPlayerLib/2.17.1 / samsung (SM-G996B)"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add apps that were in the old user-agents project but are missing here. I'm not sure if there was a reason for not migrating these entries but we are observing some traffic with them that is not matching to ExoPlayerLib instead.