### PR TITLE
Update referrers.json

### DIFF
--- a/build/referrers.runtime.json
+++ b/build/referrers.runtime.json
@@ -95,7 +95,7 @@
     },
     {
       "name": "Headliner",
-      "pattern": "^https\\://make\\.headliner\\.app/",
+      "pattern": "^https\\://(make\\.)?headliner\\.(app|link)/",
       "category": "app"
     },
     {

--- a/src/referrers.json
+++ b/src/referrers.json
@@ -169,7 +169,7 @@
     },
     {
       "name": "Headliner",
-      "pattern": "^https\\://make\\.headliner\\.app/",
+      "pattern": "^https\\://(make\\.)?headliner\\.(app|link)/",
       "examples": [
         "https://make.headliner.app/"
       ],


### PR DESCRIPTION
<img width="345" alt="Screenshot 2024-03-03 at 9 11 35 pm" src="https://github.com/opawg/user-agents-v2/assets/231941/d63d7a2f-a185-4500-affa-556879523126">

Above - Headliner is using another TLD as well - I'm seeing traffic from headliner.link as well as traffic from the naked headliner.app domain as well. I think this should, if you'll pardon the Pokemon reference, catch 'em all.