### PR TITLE
Added DRN1 user-agent to apps.json

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -1263,8 +1263,13 @@
     {
       "name": "DRN1",
       "pattern": "^DRN1;",
+      "urls": [
+        "https://www.drn1.com.au/",
+        "https://www.drn1.com"
+      ],
       "examples": [
         "DRN1; iPhone; iOS 17.4.1"
+        "DRN1; Android; Samsung 17.4.1"
       ]
     },
     {

--- a/src/apps.json
+++ b/src/apps.json
@@ -1268,7 +1268,7 @@
         "https://www.drn1.com"
       ],
       "examples": [
-        "DRN1; iPhone; iOS 17.4.1"
+        "DRN1; iPhone; iOS 17.4.1",
         "DRN1; Android; Samsung 17.4.1"
       ]
     },

--- a/src/apps.json
+++ b/src/apps.json
@@ -1261,6 +1261,13 @@
       ]
     },
     {
+      "name": "DRN1",
+      "pattern": "^DRN1;",
+      "examples": [
+        "DRN1; iPhone; iOS 17.4.1"
+      ]
+    },
+    {
       "name": "DroolRadio",
       "pattern": "^DroolRadio/",
       "examples": [


### PR DESCRIPTION
DRN1 is an online radio station which has Podcasts inside it's apps, it now sends a custom user-agent along with all podcast and live streaming (icecast) requests.