### PR TITLE
add agma bot to bots.json

### DIFF
--- a/src/bots.json
+++ b/src/bots.json
@@ -22,6 +22,16 @@
       ]
     },
     {
+      "name": "ma Podcast (agma) Bot",
+      "pattern": "^agma/",
+      "urls": [
+        "https://www.agma-mmc.de/media-analyse/ma-podcast"
+      ],
+      "examples": [
+        "agma/1.0"
+      ]
+    },
+    {
       "name": "AhrefsBot",
       "pattern": "AhrefsBot/",
       "urls": [


### PR DESCRIPTION
The ma Podcast is a log-file-based measurement system provided by AGMA (Arbeitsgemeinschaft Media-Analyse e.V.) that tracks and reports podcast consumption in Germany. This is their bot.

For more detailed information, you can visit their website: [AGMA ma Podcast](https://www.agma-mmc.de/media-analyse/ma-podcast).