### PR TITLE
add Podcatcher

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -2992,7 +2992,7 @@
     },
     {
       "name": "Podcatcher",
-      "pattern": "^Podcatcher ",
+      "pattern": "^Podcatcher \\d",
       "examples": [
         "Podcatcher 1.3",
         "Podcatcher 1.3 (+https://podcatcher.net)"

--- a/src/bots.json
+++ b/src/bots.json
@@ -866,10 +866,9 @@
       ]
     },
     {
-      "name": "Podcatcher",
+      "name": "Podcatcher Bot",
       "pattern": "^Podcatcher Bot 1.0",
       "examples": [
-        "Podcatcher 0.1",
         "Podcatcher Bot 1.0",
         "Podcatcher Bot 1.0 (1 subscribers; +https://podcatcher.net)"
       ]


### PR DESCRIPTION
Thanks for maintaining this repo!

There is a bug in the currently-released versions of Podcatcher that makes it so that the user agent gets reported as `net/http-easy ...` (which I noticed was recently added to the `libraries.json` file). Should I add that to the examples also, or not?