### PR TITLE
Add Seekr iOS and Android user-agents

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3855,6 +3855,9 @@
     {
       "name": "Seekr (Android)",
       "pattern": "^Seekr/.*Android",
+      "urls": [
+        "https://www.seekyoursounds.com"
+      ],
       "examples": [
         "Seekr/1.6.0.748-debug Dalvik/2.1.0 (Linux; U; Android 14; SM-S928W Build/UP1A.231005.007)"
       ]
@@ -3862,6 +3865,9 @@
     {
       "name": "Seekr (iOS)",
       "pattern": "^Seekr/.*CFNetwork",
+      "urls": [
+        "https://www.seekyoursounds.com"
+      ],
       "examples": [
         "Seekr/1077 CFNetwork/3826.400.120 Darwin/24.3.0"
       ]

--- a/src/apps.json
+++ b/src/apps.json
@@ -3853,6 +3853,20 @@
       "comments": "aka Samsung Free"
     },
     {
+      "name": "Seekr (Android)",
+      "pattern": "^Seekr/.*Android",
+      "examples": [
+        "Seekr/1.6.0.748-debug Dalvik/2.1.0 (Linux; U; Android 14; SM-S928W Build/UP1A.231005.007)"
+      ]
+    },
+    {
+      "name": "Seekr (iOS)",
+      "pattern": "^Seekr/.*CFNetwork",
+      "examples": [
+        "Seekr/1077 CFNetwork/3826.400.120 Darwin/24.3.0"
+      ]
+    },
+    {
       "name": "ServeStream",
       "pattern": "^ServeStream Dynamo/|^ServeStream$",
       "examples": [


### PR DESCRIPTION
Thank you for maintaining the repo!

Added Seekr iOS and Android user-agents to the OPAWG list for proper identification in analytics platforms. Seekr is a podcast discovery and listening app available on iOS and Android.