### PR TITLE
Add WNYC iOS, Android and website

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4504,7 +4504,7 @@
     },
     {
       "name": "WNYC",
-      "pattern": "^WNYC-App/|^WNYC%20App/",
+      "pattern": "^WNYC(-|%20| )App/",
       "examples": [
         "WNYC-App/iOS 4.4.3; iPhone; iOS 18.5",
         "WNYC App/3.0.32-11141 iOS/12.5.7 device/iPad4%2C4"

--- a/src/apps.json
+++ b/src/apps.json
@@ -4503,6 +4503,14 @@
       ]
     },
     {
+      "name": "WNYC",
+      "pattern": "^WNYC-App/|^WNYC%20App/",
+      "examples": [
+        "WNYC-App/iOS 4.4.3; iPhone; iOS 18.5",
+        "WNYC App/3.0.32-11141 iOS/12.5.7 device/iPad4%2C4"
+      ]
+    },
+    {
       "name": "WOWY Radio",
       "pattern": "^Wowy Radio/\\d",
       "examples": [

--- a/src/referrers.json
+++ b/src/referrers.json
@@ -588,6 +588,14 @@
         "https://podcasts.wixapps.net/"
       ],
       "category": "host"
+    },
+    {
+      "name": "WNYC",
+      "pattern": "^https://wnyc\\.org",
+      "examples": [
+        "https://wnyc.org/"
+      ],
+      "category": "app"
     }
   ]
 }


### PR DESCRIPTION
Added the WNYC iOS and Android user-agents to the OPAWG list for proper identification in analytics platforms. 

Also added WNYC.org, the station website, to the list of referrers.

WNYC is the public radio station for New York City. Our app supports live listening and on-demand download of podcasts. 