### PR TITLE
fix: loosen filedownloader regex, alexa devices

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -143,7 +143,7 @@
     },
     {
       "name": "Alexa-enabled device",
-      "pattern": "^AlexaMediaPlayer/[\\dv]|^Echo/|^AlexaService/|^Alexa Mobile Voice/|^Amazon;Echo",
+      "pattern": "^AlexaMediaPlayer/[\\dv]|^Echo/|^AlexaService/|^Alexa Mobile Voice/|^Amazon;Echo|^AmazonAVS/|^AvsDeviceSdk/",
       "svg": "amazon.svg",
       "examples": [
         "Echo/1.0(APNG)",
@@ -154,7 +154,9 @@
         "Amazon;Echo_Dot;27d4dfe427b34d57995b463e5d63198d;;tpapi;3.199.422",
         "Amazon;Echo_Dot_with_clock;27d4dfe427b34d57995b463e5d63198d;;tpapi;3.199.422",
         "Amazon;Echo_Show_5;27d4dfe427b34d57995b463e5d63198d;;tpapi;3.199.422",
-        "Amazon;Echo;27d4dfe427b34d57995b463e5d63198d;;tpapi;3.199.422"
+        "Amazon;Echo;27d4dfe427b34d57995b463e5d63198d;;tpapi;3.199.422",
+        "AmazonAVS/2.3",
+        "AvsDeviceSdk/1.23.0"
       ]
     },
     {

--- a/src/libraries.json
+++ b/src/libraries.json
@@ -197,9 +197,10 @@
     },
     {
       "name": "FileDownloader (Android)",
-      "pattern": "^FileDownloader/",
+      "pattern": "^FileDownloader(/|$)",
       "examples": [
-        "FileDownloader/1.7.7"
+        "FileDownloader/1.7.7",
+        "FileDownloader"
       ],
       "urls": [
         "https://github.com/lingochamp/FileDownloader"


### PR DESCRIPTION
## Description
Updates the regular expressions for `Alexa-enabled device` to include two new patterns, as well as loosened the `FileDownloader (Android)` pattern to not always require the `/`. This is based off user agent data we've observed at beehiiv that were not being matched against the existing OPAWG user agents list. 