### PR TITLE
chore: adds cloudconvert, gemini, other user agents

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -3998,6 +3998,12 @@
       ]
     },
     {
+      "name": "ReadYou",
+      "pattern": "^ReadYou/",
+      "examples": ["ReadYou/0.13.1(32)"],
+      "urls": ["https://github.com/ReadYouApp/ReadYou"]
+    },
+    {
       "name": "Reeder",
       "pattern": "^Reeder/",
       "examples": [

--- a/src/apps.json
+++ b/src/apps.json
@@ -4001,7 +4001,9 @@
       "name": "ReadYou",
       "pattern": "^ReadYou/",
       "examples": ["ReadYou/0.13.1(32)"],
-      "urls": ["https://github.com/ReadYouApp/ReadYou"]
+      "urls": [
+        "https://github.com/ReadYouApp/ReadYou"
+      ]
     },
     {
       "name": "Reeder",

--- a/src/apps.json
+++ b/src/apps.json
@@ -4000,7 +4000,9 @@
     {
       "name": "ReadYou",
       "pattern": "^ReadYou/",
-      "examples": ["ReadYou/0.13.1(32)"],
+      "examples": [
+        "ReadYou/0.13.1(32)"
+      ],
       "urls": [
         "https://github.com/ReadYouApp/ReadYou"
       ]

--- a/src/bots.json
+++ b/src/bots.json
@@ -476,7 +476,9 @@
     {
       "name": "CloudConvert",
       "pattern": "^CloudConvert",
-      "examples": ["CloudConvert"],
+      "examples": [
+        "CloudConvert"
+      ],
       "urls": [
         "https://cloudconvert.com/"
       ]
@@ -758,7 +760,9 @@
     {
       "name": "Google Gemini",
       "pattern": "^GoogleAgent-URLContext",
-      "examples": ["GoogleAgent-URLContext"],
+      "examples": [
+        "GoogleAgent-URLContext"
+      ],
       "urls": [
         "https://ai.google.dev/gemini-api/docs/url-context"
       ]
@@ -1074,7 +1078,9 @@
     {
       "name": "Metapodcast",
       "pattern": "^MetapodcastV2/",
-      "examples": ["MetapodcastV2/1.0"],
+      "examples": [
+        "MetapodcastV2/1.0"
+      ],
       "urls": [
         "https://metapodcast.net/"
       ]

--- a/src/bots.json
+++ b/src/bots.json
@@ -474,6 +474,12 @@
       ]
     },
     {
+      "name": "CloudConvert",
+      "pattern": "^CloudConvert",
+      "examples": ["CloudConvert"],
+      "urls": ["https://cloudconvert.com/"]
+    },
+    {
       "name": "Cloudflare SSL detector",
       "pattern": "^Cloudflare-SSLDetector",
       "examples": [
@@ -746,6 +752,12 @@
       "urls": [
         "http://www.google.com/adsbot.html"
       ]
+    },
+    {
+      "name": "Google Gemini",
+      "pattern": "^GoogleAgent-URLContext",
+      "examples": ["GoogleAgent-URLContext"],
+      "urls": ["https://ai.google.dev/gemini-api/docs/url-context"]
     },
     {
       "name": "Google Podcasts Manager",
@@ -1054,6 +1066,12 @@
       "urls": [
         "https://metacast.app/"
       ]
+    },
+    {
+      "name": "Metapodcast",
+      "pattern": "^MetapodcastV2/",
+      "examples": ["MetapodcastV2/1.0"],
+      "urls": ["https://metapodcast.net/"]
     },
     {
       "name": "Microsoft Bingbot",

--- a/src/bots.json
+++ b/src/bots.json
@@ -477,7 +477,9 @@
       "name": "CloudConvert",
       "pattern": "^CloudConvert",
       "examples": ["CloudConvert"],
-      "urls": ["https://cloudconvert.com/"]
+      "urls": [
+        "https://cloudconvert.com/"
+      ]
     },
     {
       "name": "Cloudflare SSL detector",
@@ -757,7 +759,9 @@
       "name": "Google Gemini",
       "pattern": "^GoogleAgent-URLContext",
       "examples": ["GoogleAgent-URLContext"],
-      "urls": ["https://ai.google.dev/gemini-api/docs/url-context"]
+      "urls": [
+        "https://ai.google.dev/gemini-api/docs/url-context"
+      ]
     },
     {
       "name": "Google Podcasts Manager",
@@ -1071,7 +1075,9 @@
       "name": "Metapodcast",
       "pattern": "^MetapodcastV2/",
       "examples": ["MetapodcastV2/1.0"],
-      "urls": ["https://metapodcast.net/"]
+      "urls": [
+        "https://metapodcast.net/"
+      ]
     },
     {
       "name": "Microsoft Bingbot",

--- a/src/devices.json
+++ b/src/devices.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "Other Smart TV",
-      "pattern": "SmartTV|[Rr]oku|CrKey|AFTT Build|AFTM Build|BRAVIA 4K|Opera TV|SmartTv|TSBNetTV|SMART-TV|SMART_TV|TV Safari|WebTV|InettvBrowser|GoogleTV|HbbTV|smart-tv|TVStick|olleh tv|^sony_tv;ps5;|Microsoft Xbox|^microsoft;xbox_|^Google;Chromecast|^TCL;|^Xiaomi;(MIBOX|MiTV-)|^samsung;(un|qn|ue|uj|ua|ls|qe|qa|lh|gq|gu)\\d|^hisense;(c235x|c205x)|^skyworth;(NoblexTV|SWTV)|^Sony;BRAVIA|^tcl;(c1\\d{2}x|7140x)|^onn\\.;8821x|^Funai;PHILIPS4KTV|^Sagemcom;(VSB|DIW)|^TPV;[A-Z0-9]+AndroidTV;|^(CVT_NULL|MediaTek);SMARTTV;|^NVIDIA;SHIELDAndroidTV|UHDAndroidTV;|^westinghouse;7808x;|^ZTE;B820C|Sky, (ES|EM)|^Cinemo/\\d| Cinemo/\\d|^Amazon;(AFTSSS|AFTMM|AFTSS|AFTKA|AFTT|AFTDCT31|AFTKM|AFTKRT|AFTHA004|AFTEAMR311);|^nowtv;|^SEIRobotics;yes|^Changhong;AIPONT|^Arcadyan;Bouygtel|^Amlogic;ONVO|^Philips;TPM|^MediaTek;39LHA120TP",
+      "pattern": "SmartTV|[Rr]oku|CrKey|AFTT Build|AFTM Build|BRAVIA 4K|Opera TV|SmartTv|TSBNetTV|SMART-TV|SMART_TV|TV Safari|WebTV|InettvBrowser|GoogleTV|HbbTV|smart-tv|TVStick|olleh tv|^sony_tv;ps5;|Microsoft Xbox|^microsoft;xbox_|^Google;Chromecast|^TCL;|^Xiaomi;(MIBOX|MiTV-)|^samsung;(un|qn|ue|uj|ua|ls|qe|qa|lh|gq|gu)\\d|^hisense;(c235x|c205x)|^skyworth;(NoblexTV|SWTV)|^Sony;BRAVIA|^tcl;(c1\\d{2}x|7140x)|^onn\\.;8821x|^Funai;PHILIPS4KTV|^Sagemcom;(VSB|DIW)|^TPV;[A-Z0-9]+AndroidTV;|^(CVT_NULL|MediaTek);SMARTTV;|^NVIDIA;SHIELDAndroidTV|UHDAndroidTV;|^westinghouse;7808x;|^ZTE;B820C|Sky, (ES|EM)|^Cinemo/\\d| Cinemo/\\d|^Amazon;(AFTSSS|AFTMM|AFTSS|AFTKA|AFTT|AFTDCT31|AFTKM|AFTKRT|AFTHA004|AFTEAMR311);|^nowtv;|^SEIRobotics;yes|^Changhong;AIPONT|^Arcadyan;Bouygtel|^Amlogic;ONVO|^Philips;TPM|^MediaTek;39LHA120TP|^samsung-agent/",
       "category": "smart_tv",
       "comments": "Must be before Android Phones",
       "examples": [
@@ -167,7 +167,8 @@
         "Philips;TPM191E;756a522d9f1648b89e76e80be654456a;;tpapi;3.122.67",
         "MediaTek;39LHA120TP;756a522d9f1648b89e76e80be654456a;;tpapi;3.127.32",
         "samsung;gq55q60tguxzg;568a50c7e7f64fe3b44a3316ef5590fd;;tpapi;3.194.71",
-        "samsung;gu50tu7079uxzg;568a50c7e7f64fe3b44a3316ef5590fd;;tpapi;3.194.71"
+        "samsung;gu50tu7079uxzg;568a50c7e7f64fe3b44a3316ef5590fd;;tpapi;3.194.71",
+        "samsung-agent/1.1"
       ]
     },
     {

--- a/src/libraries.json
+++ b/src/libraries.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "AppleCoreMedia",
-      "pattern": "^AppleCoreMedia/1",
+      "pattern": "^AppleCoreMedia(/|$",
       "description": "AppleCoreMedia library",
       "urls": [
         "https://podnews.net/article/applecoremedia-user-agent"
@@ -102,6 +102,17 @@
         "axios/0.26.1"
       ],
       "category": "bot"
+    },
+    {
+      "name": "Bruno",
+      "description": "Bruno is a modern, open-source API client used for testing and interacting with APIs",
+      "pattern": "^bruno-runtime/",
+      "examples": [
+        "bruno-runtime/3.2.2"
+      ],
+      "urls": [
+        "https://www.usebruno.com/"
+      ]
     },
     {
       "name": "Bubble (no-code)",

--- a/src/libraries.json
+++ b/src/libraries.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "AppleCoreMedia",
-      "pattern": "^AppleCoreMedia(/|$",
+      "pattern": "^AppleCoreMedia(/|$)",
       "description": "AppleCoreMedia library",
       "urls": [
         "https://podnews.net/article/applecoremedia-user-agent"


### PR DESCRIPTION
Adds new user agents based off traffic we've identified from the beehiiv platform: 

- `CloudConvert` — the online hosted downloader and conversion tool
- `Google Gemini` — the AI agent when it downloads using its [URL context tool](https://ai.google.dev/gemini-api/docs/url-context)
- `ReadYou` — a common Android RSS [reader](https://github.com/ReadYouApp/ReadYou)
- `Metapodcast` — an [AI transcription software](https://metapodcast.net/) that can download any podcast
- `Bruno` — a Postman/Insomnia alternative [local API client](https://github.com/usebruno/bruno)

This PR also expands the `AppleCoreMedia` user agent identifier based off traffic we've seen and expands the `Other Smart TV` category to include an additional common Samsung TV user agent identifier.