### PR TITLE
Add Car Curious

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -962,6 +962,17 @@
       ]
     },
     {
+      "name": "Car Curious",
+      "pattern": "^CarCurious/",
+      "description": "Podcast player for automotive shows, surfacing timestamped annotations for the cars, parts and terms mentioned in an episode",
+      "urls": [
+        "https://getcarcurious.com"
+      ],
+      "examples": [
+        "CarCurious/1.0 (iOS; +https://getcarcurious.com)"
+      ]
+    },
+    {
       "name": "Cast",
       "pattern": "^Cast/",
       "examples": [

--- a/src/referrers.json
+++ b/src/referrers.json
@@ -65,6 +65,14 @@
       "category": "host"
     },
     {
+      "name": "Car Curious",
+      "pattern": "^https://getcarcurious\\.com/",
+      "examples": [
+        "https://getcarcurious.com/"
+      ],
+      "category": "app"
+    },
+    {
       "name": "Castamatic",
       "pattern": "://castamatic\\.com/",
       "examples": [


### PR DESCRIPTION
[Car Curious](https://getcarcurious.com) is a podcast player for automotive shows. It surfaces timestamped annotations for the cars, parts and terms mentioned in an episode. There is an iOS app and a web player.

Two entries, because hosts match the two clients on different headers.

### `src/referrers.json`, the web player

The web player is a plain `<audio>` element pointed at the enclosure. It cannot set a User-Agent, so hosts match it on the `Referer`.

You can check this half today. Every episode page serves the enclosure to anonymous visitors, no login:

https://getcarcurious.com/episodes/ep-367-bill-s-thoughts-on-so-cal-month-brian-reed-dkp-ii

Press play. The request goes to `traffic.libsyn.com/...?dest-id=4819480` carrying `Referer: https://getcarcurious.com/`. We set no `Referrer-Policy`, so browsers apply their `strict-origin-when-cross-origin` default and Libsyn receives the origin with no path. That is why the example holds an origin rather than a full URL.

### `src/apps.json`, the iOS app

The app sends `CarCurious/<version> (iOS; +https://getcarcurious.com)` on both its download and its streaming path, so a play reaches you the same way whichever path the app picks.

The app ships on TestFlight today. There is no App Store listing for `urls` yet, and no public source for you to check the UA against. If you would rather not carry an entry you cannot verify, I will drop this half and reopen it once we ship. The referrer entry stands on its own. Tell me which you prefer.

### Notes

I ran `prettier --check src/*.json` and `deno test` locally. Examples match their own patterns, and neither pattern collides with another entry in either direction.

One note on the streaming path, in case it helps you elsewhere. The header has to go into the `AVURLAsset` at construction. Otherwise AVFoundation issues its own range requests as `AppleCoreMedia`, which may explain other iOS apps that surface in your data only some of the time.