### PR TITLE
Add The Podcast App (Magnolia Apps)

### DIFF
--- a/src/apps.json
+++ b/src/apps.json
@@ -4592,6 +4592,21 @@
       ]
     },
     {
+      "name": "The Podcast App (Magnolia Apps)",
+      "pattern": "^TPA/\\d|^TPA-Wear/",
+      "description": "Free podcast player for iOS, Android and Wear OS by Magnolia Apps. Not related to the existing \"The Podcast App\" entry (podcast.app / com.evolve.podcast).",
+      "urls": [
+        "https://thepodcastapp.dev",
+        "https://apps.apple.com/app/the-podcast-app/id6754806244",
+        "https://play.google.com/store/apps/details?id=com.magnolia.thepodcastapp"
+      ],
+      "comments": "Developer-submitted. TPA-Wear/ is the Wear OS build; TPA/ is the phone app (Android and iOS).",
+      "examples": [
+        "TPA/3.0.468 (+https://thepodcastapp.dev)",
+        "TPA-Wear/1.0"
+      ]
+    },
+    {
       "name": "Twipe Mobile App",
       "pattern": "^TwipeMobileApp",
       "examples": [


### PR DESCRIPTION
This adds The Podcast App by Magnolia Apps (https://thepodcastapp.dev) — a free podcast player for iOS, Android and Wear OS.

I'm the developer. Our user agents:

- `TPA/{app-version} (+https://thepodcastapp.dev)` — RSS feed, audio, and API requests from the phone/tablet app (rolling out in the current release).
- `TPA-Wear/1.0` — audio requests from the standalone Wear OS build (already in the wild).

Naming/pattern notes:

- This app is unrelated to the existing "The Podcast App" entry (podcast.app / `com.evolve.podcast`), hence the disambiguated entry name. Our token is `TPA/` specifically so the two apps stay deterministically separable — the pattern `^TPA/\d|^TPA-Wear/` does not intersect the existing `^ThePodcastApp` pattern.
- Verified against the matching algorithm in the README: both examples resolve uniquely to this entry, and the pattern matches no existing entry's examples across the src files.

Happy to adjust the entry name or pattern if you'd prefer a different disambiguation convention.